### PR TITLE
Make CE melee weapons viable as relics

### DIFF
--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -19,6 +19,7 @@
       <Beauty>-3</Beauty>
       <SellPriceFactor>0.20</SellPriceFactor>
     </statBases>
+    <relicChance>1</relicChance>
     <comps>
       <li Class="CompProperties_Forbiddable"/>
       <li>
@@ -32,6 +33,7 @@
         <descriptionMaker>ArtDescription_WeaponMelee</descriptionMaker>
         <minQualityForArtistic>Excellent</minQualityForArtistic>
       </li>
+      <li Class="CompProperties_Styleable"></li>
     </comps>
     <graphicData>
       <onGroundRandomRotateAngle>35</onGroundRandomRotateAngle>


### PR DESCRIPTION
CE melee weapons can't be chosen as relics so I made a small change to make it possible.
Tested in-game with no errors and could choose CE melee weapons as relics.