### PR TITLE
Fix powered melee weapon's research position

### DIFF
--- a/1.3/Defs/ResearchProjects_MeleeWeapons.xml
+++ b/1.3/Defs/ResearchProjects_MeleeWeapons.xml
@@ -14,7 +14,7 @@
     <prerequisites>
       <li>Fabrication</li>
     </prerequisites>
-    <researchViewX>13</researchViewX>
+    <researchViewX>14</researchViewX>
     <researchViewY>5.4</researchViewY>
   </ResearchProjectDef>
   

--- a/1.3/Defs/ResearchProjects_MeleeWeapons.xml
+++ b/1.3/Defs/ResearchProjects_MeleeWeapons.xml
@@ -14,7 +14,7 @@
     <prerequisites>
       <li>Fabrication</li>
     </prerequisites>
-    <researchViewX>14</researchViewX>
+    <researchViewX>15</researchViewX>
     <researchViewY>5.4</researchViewY>
   </ResearchProjectDef>
   


### PR DESCRIPTION
The research project unlocking powered melee weapons is currently in a weird place colliding with other projects.