### PR TITLE
Add thingSetMakerTags to the melee weapons

### DIFF
--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -19,7 +19,7 @@
       <Beauty>-3</Beauty>
       <SellPriceFactor>0.20</SellPriceFactor>
     </statBases>
-    <relicChance>1</relicChance>
+    <relicChance>2</relicChance>
     <comps>
       <li Class="CompProperties_Forbiddable"/>
       <li>
@@ -151,6 +151,9 @@
         <Crafting>4</Crafting>
       </skillRequirements>
     </recipeMaker>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.25,1.10</DrawSize>
@@ -235,6 +238,9 @@
       <MeleeParryChance>0.5</MeleeParryChance>
       <MeleeDodgeChance>0.5</MeleeDodgeChance>
     </equippedStatOffsets>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.28,1.28</DrawSize>
@@ -319,6 +325,9 @@
       <MeleeParryChance>1.53</MeleeParryChance>
       <MeleeDodgeChance>0.67</MeleeDodgeChance>
     </equippedStatOffsets>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.6,1.5</DrawSize>
@@ -382,6 +391,9 @@
       <MeleeParryChance>0.23</MeleeParryChance>
       <MeleeDodgeChance>0.2</MeleeDodgeChance>
     </equippedStatOffsets>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.10,1.10</DrawSize>
@@ -458,6 +470,9 @@
       <MeleeParryChance>0.46</MeleeParryChance>
       <MeleeDodgeChance>0.2</MeleeDodgeChance>
     </equippedStatOffsets>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.10,1.10</DrawSize>
@@ -508,6 +523,9 @@
       <MeleeParryChance>0.34</MeleeParryChance>
       <MeleeDodgeChance>0.3</MeleeDodgeChance>
     </equippedStatOffsets>
+    <thingSetMakerTags>
+      <li>RewardStandardQualitySuper</li>
+    </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">
         <DrawSize>1.30,1.20</DrawSize>
@@ -581,6 +599,7 @@
     </equippedStatOffsets>
     <thingSetMakerTags>
       <li>RewardStandardLowFreq</li>
+      <li>RewardStandardQualitySuper</li>
     </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">

--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -51,13 +51,6 @@
     </inspectorTabs>
   </ThingDef>
 
-  <!--<ThingDef Name="PoweredMeleeWeapon_CE" ParentName="BaseMeleeWeapon_CE" Abstract="True">
-    <techLevel>Spacer</techLevel>
-    <weaponTags>
-      <li>SpacerGun</li>
-    </weaponTags>
-  </ThingDef>-->
-
   <ThingDef Name="MeleeWeaponMakeable_CE" ParentName="BaseMeleeWeapon_CE" Abstract="True">
     <recipeMaker>
       <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
@@ -548,12 +541,13 @@
       <texPath>Things/Weapons/WraithBlade</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
+    <tradeability>Sellable</tradeability>
     <techLevel>Ultra</techLevel>
     <statBases>
       <Mass>1</Mass>
       <Bulk>8</Bulk>
       <MeleeCounterParryBonus>1.6</MeleeCounterParryBonus>
-      <MarketValue>7000</MarketValue>
+      <MarketValue>4000</MarketValue>
     </statBases>
     <equippedAngleOffset>-45</equippedAngleOffset>
     <weaponTags inherit="false" />
@@ -599,7 +593,6 @@
     </equippedStatOffsets>
     <thingSetMakerTags>
       <li>RewardStandardLowFreq</li>
-      <li>RewardStandardQualitySuper</li>
     </thingSetMakerTags>
     <modExtensions>
       <li Class="CombatExtended.GunDrawExtension">


### PR DESCRIPTION
- Added thingSetMakerTags which in turn mean quest reward tags to the melee weapons added by the mod.

- Change the Wraithbalde to be only a quest reward item with a low chance as it was too easy to obtain, adjusted its market value give it a chance as a quest reward option. Anything above 5.5K market value won't show up as a quest reward. The new market value should not matter as much anymore since it's a quest reward only item.