### PR TITLE
Fixed the stuffCategories of stuffable melee weapons

### DIFF
--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -119,7 +119,7 @@
     </statBases>
     <equippedAngleOffset>-25</equippedAngleOffset>
     <stuffCategories>
-      <li>Metallic</li>
+      <li>Metallic_Weapon</li>
       <li>Woody</li>
     </stuffCategories>
     <tools>
@@ -182,7 +182,7 @@
     </statBases>
     <equippedAngleOffset>-45</equippedAngleOffset>
     <stuffCategories>
-      <li>Metallic</li>
+      <li>Metallic_Weapon</li>
     </stuffCategories>
     <tools>
       <li Class="CombatExtended.ToolCE">
@@ -269,7 +269,7 @@
     </statBases>
     <equippedAngleOffset>-25</equippedAngleOffset>
     <stuffCategories>
-      <li>Metallic</li>
+      <li>Metallic_Weapon</li>
     </stuffCategories>
     <tools>
       <li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
All stuffable melee weapons have the Metallic_Weapon stuffCategories except the CE Melee ones which this PR aims to fix that oversight.

Metallic_Weapon excludes materials like gold and silver from being used in crafting melee weapons.