### PR TITLE
Wraithblade custom Toughness rating

### DIFF
--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -548,6 +548,7 @@
       <Bulk>8</Bulk>
       <MeleeCounterParryBonus>1.6</MeleeCounterParryBonus>
       <MarketValue>4000</MarketValue>
+      <ToughnessRating>50</ToughnessRating>
     </statBases>
     <equippedAngleOffset>-45</equippedAngleOffset>
     <weaponTags inherit="false" />

--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -544,7 +544,7 @@
     <tradeability>Sellable</tradeability>
     <techLevel>Ultra</techLevel>
     <statBases>
-      <MaxHitPoints>100</MaxHitPoints>
+      <MaxHitPoints>200</MaxHitPoints>
       <Mass>1</Mass>
       <Bulk>8</Bulk>
       <MeleeCounterParryBonus>1.6</MeleeCounterParryBonus>

--- a/1.3/Defs/Weapons_CE_Melee.xml
+++ b/1.3/Defs/Weapons_CE_Melee.xml
@@ -544,6 +544,7 @@
     <tradeability>Sellable</tradeability>
     <techLevel>Ultra</techLevel>
     <statBases>
+      <MaxHitPoints>100</MaxHitPoints>
       <Mass>1</Mass>
       <Bulk>8</Bulk>
       <MeleeCounterParryBonus>1.6</MeleeCounterParryBonus>


### PR DESCRIPTION
Gave the Wraithblade a custom ToughnessRating in preparation for the weapon toughness system.

The value was chosen to make them strong enough against attacks with high armor penetration as the ToughnessRating is used against the attack's armor pen value to determine the damage done to the weapon.

_Not to be merged until the system gets implemented in main CE_