### PR TITLE
Tweak the trade tag

### DIFF
--- a/1.4/Defs/Weapons_CE_Melee.xml
+++ b/1.4/Defs/Weapons_CE_Melee.xml
@@ -61,13 +61,13 @@
     <inspectorTabs>
       <li>ITab_Art</li>
     </inspectorTabs>
+    <tradeTags>
+      <li>WeaponMelee</li>
+    </tradeTags>
     <allowedArchonexusCount>1</allowedArchonexusCount>
   </ThingDef>
 
   <ThingDef Name="MeleeWeaponMakeable_CE" ParentName="BaseMeleeWeapon_CE" Abstract="True">
-    <tradeTags>
-      <li>WeaponMelee</li>
-    </tradeTags>
     <recipeMaker>
       <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
       <workSkill>Crafting</workSkill>


### PR DESCRIPTION
Brought the `WeaponMelee` trade tag to CE's melee weapon parent def since the Wraith Blade can uses it too.