### PR TITLE
Add IgnoreIfNoMatchingField to modIconPath

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -4,7 +4,7 @@
 	<author>CE Team</author>
 	<url>https://github.com/CombatExtended-Continued/CombatExtendedMelee</url>
 	<description>Version: 5.1.1.0\n\nAdds several new melee weapons to take advantage of CE mechanics.</description>
-	<modIconPath>UI/Icons/CE_ModIcon_JustHat</modIconPath>
+	<modIconPath IgnoreIfNoMatchingField="True">UI/Icons/CE_ModIcon_JustHat</modIconPath>
 	<supportedVersions>
 		<li>1.3</li>
 		<li>1.4</li>


### PR DESCRIPTION
## Changes

As title says - just added `IgnoreIfNoMatchingField="True"` to `modIconPath` so that it doesn't throw errors on previous rimworld versions
