### PR TITLE
Wraith Blade commonality tweak

### DIFF
--- a/1.4/Defs/Weapons_CE_Melee.xml
+++ b/1.4/Defs/Weapons_CE_Melee.xml
@@ -591,7 +591,7 @@
 			<MarketValue>3000</MarketValue>
 			<ToughnessRating>50</ToughnessRating>
 		</statBases>
-		<generateCommonality>0.5</generateCommonality>
+		<generateCommonality>0.25</generateCommonality>
 		<relicChance>1</relicChance>
 		<equippedAngleOffset>-45</equippedAngleOffset>
 		<weaponTags>

--- a/1.5/Defs/Weapons_CE_Melee.xml
+++ b/1.5/Defs/Weapons_CE_Melee.xml
@@ -591,7 +591,7 @@
 			<MarketValue>3000</MarketValue>
 			<ToughnessRating>50</ToughnessRating>
 		</statBases>
-		<generateCommonality>0.5</generateCommonality>
+		<generateCommonality>0.25</generateCommonality>
 		<relicChance>1</relicChance>
 		<equippedAngleOffset>-45</equippedAngleOffset>
 		<weaponTags>


### PR DESCRIPTION
Reduced the commonality of the Wraith Blade from 0.5 to 0.25, they were too common considering they can spawn in trader stocks.
