### PR TITLE
Maul and Halberd recipe adjustments

### DIFF
--- a/1.4/Defs/Weapons_CE_Melee.xml
+++ b/1.4/Defs/Weapons_CE_Melee.xml
@@ -128,9 +128,9 @@
 		<weaponTags>
 			<li>MedievalMeleeAdvanced</li>
 		</weaponTags>
-		<costStuffCount>120</costStuffCount>
+		<costStuffCount>150</costStuffCount>
 		<statBases>
-			<WorkToMake>14000</WorkToMake>
+			<WorkToMake>22000</WorkToMake>
 			<Mass>3.2</Mass>
 			<Bulk>16</Bulk>
 			<MeleeCounterParryBonus>0.5</MeleeCounterParryBonus>
@@ -289,9 +289,9 @@
 		<weaponTags>
 			<li>MedievalMeleeAdvanced</li>
 		</weaponTags>
-		<costStuffCount>80</costStuffCount>
+		<costStuffCount>90</costStuffCount>
 		<statBases>
-			<WorkToMake>15000</WorkToMake>
+			<WorkToMake>20000</WorkToMake>
 			<Mass>1.8</Mass>
 			<Bulk>10</Bulk>
 			<MeleeCounterParryBonus>1.71</MeleeCounterParryBonus>

--- a/1.4/Defs/Weapons_CE_Melee.xml
+++ b/1.4/Defs/Weapons_CE_Melee.xml
@@ -289,7 +289,7 @@
 		<weaponTags>
 			<li>MedievalMeleeAdvanced</li>
 		</weaponTags>
-		<costStuffCount>90</costStuffCount>
+		<costStuffCount>110</costStuffCount>
 		<statBases>
 			<WorkToMake>20000</WorkToMake>
 			<Mass>1.8</Mass>

--- a/1.5/Defs/Weapons_CE_Melee.xml
+++ b/1.5/Defs/Weapons_CE_Melee.xml
@@ -128,9 +128,9 @@
 		<weaponTags>
 			<li>MedievalMeleeAdvanced</li>
 		</weaponTags>
-		<costStuffCount>120</costStuffCount>
+		<costStuffCount>150</costStuffCount>
 		<statBases>
-			<WorkToMake>14000</WorkToMake>
+			<WorkToMake>22000</WorkToMake>
 			<Mass>3.2</Mass>
 			<Bulk>16</Bulk>
 			<MeleeCounterParryBonus>0.5</MeleeCounterParryBonus>
@@ -289,9 +289,9 @@
 		<weaponTags>
 			<li>MedievalMeleeAdvanced</li>
 		</weaponTags>
-		<costStuffCount>80</costStuffCount>
+		<costStuffCount>90</costStuffCount>
 		<statBases>
-			<WorkToMake>15000</WorkToMake>
+			<WorkToMake>20000</WorkToMake>
 			<Mass>1.8</Mass>
 			<Bulk>10</Bulk>
 			<MeleeCounterParryBonus>1.71</MeleeCounterParryBonus>

--- a/1.5/Defs/Weapons_CE_Melee.xml
+++ b/1.5/Defs/Weapons_CE_Melee.xml
@@ -289,7 +289,7 @@
 		<weaponTags>
 			<li>MedievalMeleeAdvanced</li>
 		</weaponTags>
-		<costStuffCount>90</costStuffCount>
+		<costStuffCount>110</costStuffCount>
 		<statBases>
 			<WorkToMake>20000</WorkToMake>
 			<Mass>1.8</Mass>


### PR DESCRIPTION
## Changes

- Adjusted the recipe of the maul and halberd based on existing vanilla items, being the longsword and warhammer.

## Reasoning

- They were too cheap in comparison.
